### PR TITLE
Types: make Emoji and CompactEmoji .tags optional

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -143,7 +143,7 @@ export interface CompactEmoji {
   order: number;
   shortcodes: Shortcode[];
   skins?: CompactEmoji[];
-  tags: string[];
+  tags?: string[];
   unicode: Unicode;
 }
 
@@ -159,7 +159,7 @@ export interface Emoji {
   shortcodes: Shortcode[];
   skins?: Emoji[];
   subgroup: Subgroup;
-  tags: string[];
+  tags?: string[];
   text: Unicode;
   tone?: SkinTone | SkinTone[];
   type: Presentation;


### PR DESCRIPTION
Currently `Emoji` and `CompactEmoji` interfaces define `tags` as a required property. However, when generating emoji skins, the tags property is [deleted](https://github.com/milesj/emojibase/blob/master/packages/generator/src/generators/generateData.ts#L104). That causes a typescript type violation error.

This PR makes the tags properties on those interfaces optional and closes #30.

I considered declaring new types for skin variations but, I think, emoji and its skins are similar enough in purpose to have the same interface. Defining them as different types could force the consumer to use union type with no good reason. However, my knowledge of typescript is limited and I may be completely wrong 😄 