### PR TITLE
new: Add `slight_smile` and `slight_frown` shortcodes.

### DIFF
--- a/packages/generator/src/resources/shortcodes.ts
+++ b/packages/generator/src/resources/shortcodes.ts
@@ -63,7 +63,7 @@ export default {
   // 😂 face with tears of joy
   '1F602': ['joyful', 'haha'],
   // 🙂 slightly smiling face
-  '1F642': ['pleased'],
+  '1F642': ['pleased', 'slight_smile'],
   // 🙃 upside-down face
   '1F643': ['ecstatic', 'upside_down'],
   // 😉 winking face
@@ -139,7 +139,7 @@ export default {
   // 😟 worried face
   '1F61F': ['worried'],
   // 🙁 slightly frowning face
-  '1F641': ['cheerless'],
+  '1F641': ['cheerless', 'slight_frown'],
   // ☹️ frowning face
   '2639': ['sad', 'frowning'],
   // 😮 face with open mouth


### PR DESCRIPTION
These are commonly used, e.g. by Joypixels/Emojione: https://github.com/joypixels/emoji-toolkit/blob/master/extras/alpha-codes/eac.json

Github uses `:slightly_smiling_face:` / `:slightly_frowning_face:`. Those are a bit long, but could be added as aliases.