### PR TITLE
new: Make CDN url configurable.

### DIFF
--- a/packages/core/src/fetchFromCDN.ts
+++ b/packages/core/src/fetchFromCDN.ts
@@ -1,4 +1,4 @@
-import {FetchFromCDNOptions} from './types';
+import { FetchFromCDNOptions } from './types';
 
 /**
  * This function will fetch `emojibase-data` JSON files from our CDN, parse them,
@@ -23,8 +23,7 @@ export async function fetchFromCDN<T>(path: string, options: FetchFromCDNOptions
 	let fetchUrl = `https://cdn.jsdelivr.net/npm/emojibase-data@${version}/${path}`;
 	if (typeof cdnUrl === 'function') {
 		fetchUrl = cdnUrl(path, version);
-	}
-	else if (typeof cdnUrl === 'string') {
+	} else if (typeof cdnUrl === 'string') {
 		fetchUrl = `${cdnUrl}/${path}`;
 	}
 

--- a/packages/core/src/fetchFromCDN.ts
+++ b/packages/core/src/fetchFromCDN.ts
@@ -36,8 +36,8 @@ function getFetchUrl(path: string, version: string, cdnUrl?: CDNUrlFn | string):
  * await fetchFromCDN('ja/compact.json', { version: '2.1.3' });
  * await fetchFromCDN('ja/compact.json', { cdnUrl: 'https://example.com/cdn/emojidata/latest' });
  * await fetchFromCDN('ja/compact.json', {
- *     cdnUrl: (path: string) => {
- *         return `https://example.com/cdn/emojidata/1.2.3/${path}`;
+ *     cdnUrl: (path: string, version: string) => {
+ *         return `https://example.com/cdn/emojidata/${version}/${path}`;
  *     }
  * });
  * ```

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -294,7 +294,7 @@ export interface FetchFromCDNOptions extends RequestInit {
 	/** The release version to fetch. Defaults to `latest`. */
 	version?: string;
 	/** The url from which to load the JSON files */
-	cdnUrl?: string | CDNUrlFn;
+	cdnUrl?: CDNUrlFn | string;
 }
 
 export interface FetchEmojisOptions extends FetchFromCDNOptions {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -286,11 +286,15 @@ export interface PermutationOptions {
 	withNose?: boolean;
 }
 
+export type CDNUrlFn = (path: string, version: string) => string;
+
 export interface FetchFromCDNOptions extends RequestInit {
 	/** Cache the response in local storage instead of session storage. Defaults to `false`. */
 	local?: boolean;
 	/** The release version to fetch. Defaults to `latest`. */
 	version?: string;
+	/** The url from which to load the JSON files */
+	cdnUrl?: string | CDNUrlFn;
 }
 
 export interface FetchEmojisOptions extends FetchFromCDNOptions {

--- a/packages/core/tests/fetchFromCDN.test.ts
+++ b/packages/core/tests/fetchFromCDN.test.ts
@@ -101,7 +101,7 @@ describe('fetchFromCDN()', () => {
 	it('errors if cdnUrl function has no result', async () => {
 		const cdnUrl = (path: string): string => {
 			return '';
-		}
+		};
 		await expect(() => fetchFromCDN('en/data.json', { cdnUrl })).rejects.toThrow(
 			'A valid CDN url is required to fetch.',
 		);
@@ -110,7 +110,7 @@ describe('fetchFromCDN()', () => {
 	it('errors if cdnUrl function doesnt end in JSON', async () => {
 		const cdnUrl = (path: string) => {
 			return `https://example.com/cdn/emojidata/latest/en/data`;
-		}
+		};
 		await expect(() => fetchFromCDN('en/data.json', { cdnUrl })).rejects.toThrow(
 			'A valid CDN url is required to fetch.',
 		);
@@ -119,7 +119,7 @@ describe('fetchFromCDN()', () => {
 	it('can customize cdnUrl using function', async () => {
 		const cdnUrl = (path: string) => {
 			return `https://example.com/cdn/emojidata/latest/${path}`;
-		}
+		};
 		await fetchFromCDN('en/data.json', { cdnUrl });
 
 		expect(fetchMock).toHaveBeenCalledWith(
@@ -135,17 +135,14 @@ describe('fetchFromCDN()', () => {
 	it('can utilize version within cnbUrl function', async () => {
 		const cdnUrl = (path: string, version: string) => {
 			return `https://example.com/cdn/emojidata/${version}/${path}`;
-		}
+		};
 		await fetchFromCDN('en/data.json', { cdnUrl, version: '1.2.3' });
 
-		expect(fetchMock).toHaveBeenCalledWith(
-			'https://example.com/cdn/emojidata/1.2.3/en/data.json',
-			{
-				credentials: 'omit',
-				mode: 'cors',
-				redirect: 'error',
-			},
-		);
+		expect(fetchMock).toHaveBeenCalledWith('https://example.com/cdn/emojidata/1.2.3/en/data.json', {
+			credentials: 'omit',
+			mode: 'cors',
+			redirect: 'error',
+		});
 	});
 
 	it('returns data from fetch', async () => {

--- a/packages/core/tests/fetchFromCDN.test.ts
+++ b/packages/core/tests/fetchFromCDN.test.ts
@@ -80,6 +80,74 @@ describe('fetchFromCDN()', () => {
 		);
 	});
 
+	it('errors if no cdnUrl', async () => {
+		const cdnUrl = '';
+		await expect(() => fetchFromCDN('en/data.json', { cdnUrl })).rejects.toThrow(
+			'A valid CDN url is required to fetch.',
+		);
+	});
+
+	it('can customize cdnUrl using string', async () => {
+		const cdnUrl = 'https://example.com/cdn/emojidata/latest';
+		await fetchFromCDN('en/data.json', { cdnUrl });
+
+		expect(fetchMock).toHaveBeenCalledWith(`${cdnUrl}/en/data.json`, {
+			credentials: 'omit',
+			mode: 'cors',
+			redirect: 'error',
+		});
+	});
+
+	it('errors if cdnUrl function has no result', async () => {
+		const cdnUrl = (path: string): string => {
+			return '';
+		}
+		await expect(() => fetchFromCDN('en/data.json', { cdnUrl })).rejects.toThrow(
+			'A valid CDN url is required to fetch.',
+		);
+	});
+
+	it('errors if cdnUrl function doesnt end in JSON', async () => {
+		const cdnUrl = (path: string) => {
+			return `https://example.com/cdn/emojidata/latest/en/data`;
+		}
+		await expect(() => fetchFromCDN('en/data.json', { cdnUrl })).rejects.toThrow(
+			'A valid CDN url is required to fetch.',
+		);
+	});
+
+	it('can customize cdnUrl using function', async () => {
+		const cdnUrl = (path: string) => {
+			return `https://example.com/cdn/emojidata/latest/${path}`;
+		}
+		await fetchFromCDN('en/data.json', { cdnUrl });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://example.com/cdn/emojidata/latest/en/data.json',
+			{
+				credentials: 'omit',
+				mode: 'cors',
+				redirect: 'error',
+			},
+		);
+	});
+
+	it('can utilize version within cnbUrl function', async () => {
+		const cdnUrl = (path: string, version: string) => {
+			return `https://example.com/cdn/emojidata/${version}/${path}`;
+		}
+		await fetchFromCDN('en/data.json', { cdnUrl, version: '1.2.3' });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://example.com/cdn/emojidata/1.2.3/en/data.json',
+			{
+				credentials: 'omit',
+				mode: 'cors',
+				redirect: 'error',
+			},
+		);
+	});
+
 	it('returns data from fetch', async () => {
 		const data = await fetchFromCDN('en/data.json');
 

--- a/packages/core/tests/fetchFromCDN.test.ts
+++ b/packages/core/tests/fetchFromCDN.test.ts
@@ -99,27 +99,21 @@ describe('fetchFromCDN()', () => {
 	});
 
 	it('errors if cdnUrl function has no result', async () => {
-		const cdnUrl = (path: string): string => {
-			return '';
-		};
+		const cdnUrl = (path: string): string => '';
 		await expect(() => fetchFromCDN('en/data.json', { cdnUrl })).rejects.toThrow(
 			'A valid CDN url is required to fetch.',
 		);
 	});
 
 	it('errors if cdnUrl function doesnt end in JSON', async () => {
-		const cdnUrl = (path: string) => {
-			return `https://example.com/cdn/emojidata/latest/en/data`;
-		};
+		const cdnUrl = (path: string) => `https://example.com/cdn/emojidata/latest/en/data`;
 		await expect(() => fetchFromCDN('en/data.json', { cdnUrl })).rejects.toThrow(
 			'A valid CDN url is required to fetch.',
 		);
 	});
 
 	it('can customize cdnUrl using function', async () => {
-		const cdnUrl = (path: string) => {
-			return `https://example.com/cdn/emojidata/latest/${path}`;
-		};
+		const cdnUrl = (path: string) => `https://example.com/cdn/emojidata/latest/${path}`;
 		await fetchFromCDN('en/data.json', { cdnUrl });
 
 		expect(fetchMock).toHaveBeenCalledWith(
@@ -133,9 +127,7 @@ describe('fetchFromCDN()', () => {
 	});
 
 	it('can utilize version within cnbUrl function', async () => {
-		const cdnUrl = (path: string, version: string) => {
-			return `https://example.com/cdn/emojidata/${version}/${path}`;
-		};
+		const cdnUrl = (path: string, version: string) => `https://example.com/cdn/emojidata/${version}/${path}`;
 		await fetchFromCDN('en/data.json', { cdnUrl, version: '1.2.3' });
 
 		expect(fetchMock).toHaveBeenCalledWith('https://example.com/cdn/emojidata/1.2.3/en/data.json', {

--- a/packages/core/tests/fetchFromCDN.test.ts
+++ b/packages/core/tests/fetchFromCDN.test.ts
@@ -112,6 +112,13 @@ describe('fetchFromCDN()', () => {
 		);
 	});
 
+	it('errors if cdnUrl function doesnt start with http(s)', async () => {
+		const cdnUrl = (path: string) => `example.com/cdn/emojidata/latest/en/data`;
+		await expect(() => fetchFromCDN('en/data.json', { cdnUrl })).rejects.toThrow(
+			'A valid CDN url is required to fetch.',
+		);
+	});
+
 	it('can customize cdnUrl using function', async () => {
 		const cdnUrl = (path: string) => `https://example.com/cdn/emojidata/latest/${path}`;
 		await fetchFromCDN('en/data.json', { cdnUrl });
@@ -126,7 +133,21 @@ describe('fetchFromCDN()', () => {
 		);
 	});
 
-	it('can utilize version within cnbUrl function', async () => {
+	it('can use cdnUrl function with http', async () => {
+		const cdnUrl = (path: string) => `http://example.com/cdn/emojidata/latest/${path}`;
+		await fetchFromCDN('en/data.json', { cdnUrl });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://example.com/cdn/emojidata/latest/en/data.json',
+			{
+				credentials: 'omit',
+				mode: 'cors',
+				redirect: 'error',
+			},
+		);
+	});
+
+	it('can utilize version within cdnUrl function', async () => {
 		const cdnUrl = (path: string, version: string) =>
 			`https://example.com/cdn/emojidata/${version}/${path}`;
 		await fetchFromCDN('en/data.json', { cdnUrl, version: '1.2.3' });

--- a/packages/core/tests/fetchFromCDN.test.ts
+++ b/packages/core/tests/fetchFromCDN.test.ts
@@ -127,7 +127,8 @@ describe('fetchFromCDN()', () => {
 	});
 
 	it('can utilize version within cnbUrl function', async () => {
-		const cdnUrl = (path: string, version: string) => `https://example.com/cdn/emojidata/${version}/${path}`;
+		const cdnUrl = (path: string, version: string) =>
+			`https://example.com/cdn/emojidata/${version}/${path}`;
 		await fetchFromCDN('en/data.json', { cdnUrl, version: '1.2.3' });
 
 		expect(fetchMock).toHaveBeenCalledWith('https://example.com/cdn/emojidata/1.2.3/en/data.json', {

--- a/website/docs/datasets.mdx
+++ b/website/docs/datasets.mdx
@@ -222,6 +222,44 @@ const germanCldrShortcodes = await fetchShortcodes('de', 'cldr');
 const chineseTranslations = await fetchMessages('zh');
 ```
 
+## Fetching from your own CDN
+
+If you want to load the JSON datasets from your own CDN, you can customize the `cdnUrl` using the
+options object.
+
+When `cdnUrl` is a string, `fetchFromCDN` will append `'/${path}'` to the url. Make sure to include
+the `version` within the `cdnUrl` yourself, it's not added automatically to give you control over
+its placement.
+
+```ts
+import { fetchFromCDN, fetchEmojis, fetchMessages, fetchShortcodes } from 'emojibase';
+
+const cdnUrl = 'https://example.com/cdn/emojidata/latest';
+
+const englishEmojis = await fetchFromCDN('en/data.json', { shortcodes: ['github'], cdnUrl });
+const japaneseCompactEmojis = await fetchEmojis('ja', { compact: true, cdnUrl });
+const germanCldrShortcodes = await fetchShortcodes('de', 'cldr', { cdnUrl });
+const chineseTranslations = await fetchMessages('zh', { cdnUrl });
+```
+
+`cdnUrl` can also be a function, so you have complete control over the format of the url. This
+function receives `path` and `version` as parameters. Version will be what you pass in within
+the options object, or it will default to `latest`. You can of course ignore this parameter and
+hard-code the `version` within the function body.
+
+```ts
+import { fetchFromCDN, fetchEmojis, fetchMessages, fetchShortcodes } from 'emojibase';
+
+function cdnUrl(path: string, version: string): string {
+    return `https://example.com/cdn/emojidata/${version}/${path}`;
+}
+
+const englishEmojis = await fetchFromCDN('en/data.json', { shortcodes: ['github'], cdnUrl });
+const japaneseCompactEmojis = await fetchEmojis('ja', { compact: true, cdnUrl });
+const germanCldrShortcodes = await fetchShortcodes('de', 'cldr', { cdnUrl });
+const chineseTranslations = await fetchMessages('zh', { cdnUrl });
+```
+
 ## Supported locales
 
 Follow locales are supported for both full and compact datasets.

--- a/website/docs/datasets.mdx
+++ b/website/docs/datasets.mdx
@@ -243,15 +243,15 @@ const chineseTranslations = await fetchMessages('zh', { cdnUrl });
 ```
 
 `cdnUrl` can also be a function, so you have complete control over the format of the url. This
-function receives `path` and `version` as parameters. Version will be what you pass in within
-the options object, or it will default to `latest`. You can of course ignore this parameter and
+function receives `path` and `version` as parameters. Version will be what you pass in within the
+options object, or it will default to `latest`. You can of course ignore this parameter and
 hard-code the `version` within the function body.
 
 ```ts
 import { fetchFromCDN, fetchEmojis, fetchMessages, fetchShortcodes } from 'emojibase';
 
 function cdnUrl(path: string, version: string): string {
-    return `https://example.com/cdn/emojidata/${version}/${path}`;
+	return `https://example.com/cdn/emojidata/${version}/${path}`;
 }
 
 const englishEmojis = await fetchFromCDN('en/data.json', { shortcodes: ['github'], cdnUrl });

--- a/website/docs/datasets.mdx
+++ b/website/docs/datasets.mdx
@@ -244,8 +244,8 @@ const chineseTranslations = await fetchMessages('zh', { cdnUrl });
 
 `cdnUrl` can also be a function, so you have complete control over the format of the url. This
 function receives `path` and `version` as parameters. Version will be what you pass in within the
-options object, or it will default to `latest`. You can of course ignore this parameter and
-hard-code the `version` within the function body.
+options object, or it will default to `latest`. Note that `version` is also used for the cache key,
+so it's advised to set the option and not hard-code it in the `cdnUrl` function.
 
 ```ts
 import { fetchFromCDN, fetchEmojis, fetchMessages, fetchShortcodes } from 'emojibase';


### PR DESCRIPTION
Implementation for my feature request: #139

`cdnUrl` is a new property of the `options` object and can be a `string` or a function `(path: string, version: string): string`.

When `cdnUrl` is a `string`, it's appended with `/${path}`. Since the default URL uses `emojibase-data@latest` for version, I didn't feel comfortable making assumptions about the placement of the `version` string. So I opted for not inserting the `version` anywhere, instead relying on the `version` already being inside the configured `cdnUrl`.

When `cdnUrl` is a `function`, it receives both `path` and `version`, although I suspect the `version` parameter will generally be unused - might as well hard-code it within the function body, right?

Updated the docs to reflect the above and added tests to reflect these new capabilities.