### PR TITLE
fix: uk translations for messages

### DIFF
--- a/po/uk/messages.po
+++ b/po/uk/messages.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-09-17 14:53-0700\n"
-"PO-Revision-Date: 2024-12-03 15:57+480\n"
+"PO-Revision-Date: 2025-10-16 17:02+0300\n"
 "Last-Translator: Miles Johnson\n"
 "Language-Team: \n"
 "Language: uk\n"
@@ -12,22 +12,22 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 3.0\n"
+"X-Generator: Poedit 3.0.1\n"
 
 # 6
 msgctxt "EMOJI GROUP: activities"
 msgid "activities"
-msgstr "діяльності"
+msgstr "активність"
 
 # 3
 msgctxt "EMOJI GROUP: animals-nature"
 msgid "animals-nature"
-msgstr "тварини &amp; природа"
+msgstr "флора та фауна"
 
 # 2
 msgctxt "EMOJI GROUP: component"
 msgid "component"
-msgstr "kомпоненти"
+msgstr "компоненти"
 
 # 9
 msgctxt "EMOJI GROUP: flags"
@@ -42,17 +42,17 @@ msgstr "їжа та напої"
 # 7
 msgctxt "EMOJI GROUP: objects"
 msgid "objects"
-msgstr "об'єктів"
+msgstr "об'єкти"
 
 # 1
 msgctxt "EMOJI GROUP: people-body"
 msgid "people-body"
-msgstr "люди &amp; тіло"
+msgstr "люди"
 
 # 0
 msgctxt "EMOJI GROUP: smileys-emotion"
 msgid "smileys-emotion"
-msgstr "смайлики &amp; емоції"
+msgstr "смайлики та емоції"
 
 # 8
 msgctxt "EMOJI GROUP: symbols"
@@ -77,7 +77,7 @@ msgstr "aмфібії"
 # 35
 msgctxt "EMOJI SUB-GROUP: animal-bird"
 msgid "animal-bird"
-msgstr "птахів"
+msgstr "птахи"
 
 # 39
 msgctxt "EMOJI SUB-GROUP: animal-bug"
@@ -87,7 +87,7 @@ msgstr "помилки"
 # 34
 msgctxt "EMOJI SUB-GROUP: animal-mammal"
 msgid "animal-mammal"
-msgstr "cсавців"
+msgstr "cсавці"
 
 # 38
 msgctxt "EMOJI SUB-GROUP: animal-marine"
@@ -107,7 +107,7 @@ msgstr "стрілки"
 # 64
 msgctxt "EMOJI SUB-GROUP: arts-crafts"
 msgid "arts-crafts"
-msgstr "мистецтво &amp; ремесла"
+msgstr "мистецтво та ремесло"
 
 # 88
 msgctxt "EMOJI SUB-GROUP: av-symbol"
@@ -117,7 +117,7 @@ msgstr "аудіо та відео символи"
 # 61
 msgctxt "EMOJI SUB-GROUP: award-medal"
 msgid "award-medal"
-msgstr "нагородити медалями"
+msgstr "нагороди та медалі"
 
 # 22
 msgctxt "EMOJI SUB-GROUP: body-parts"
@@ -132,7 +132,7 @@ msgstr "книги та папір"
 # 12
 msgctxt "EMOJI SUB-GROUP: cat-face"
 msgid "cat-face"
-msgstr "кішка особи"
+msgstr "котяче обличчя"
 
 # 65
 msgctxt "EMOJI SUB-GROUP: clothing"
@@ -147,7 +147,7 @@ msgstr "комп'ютер"
 # 98
 msgctxt "EMOJI SUB-GROUP: country-flag"
 msgid "country-flag"
-msgstr "прапори країни"
+msgstr "прапори країн"
 
 # 92
 msgctxt "EMOJI SUB-GROUP: currency"
@@ -162,7 +162,7 @@ msgstr "посуд"
 # 47
 msgctxt "EMOJI SUB-GROUP: drink"
 msgid "drink"
-msgstr "питво"
+msgstr "напої"
 
 # 15
 msgctxt "EMOJI SUB-GROUP: emotion"
@@ -187,7 +187,7 @@ msgstr "занепокоєні"
 # 11
 msgctxt "EMOJI SUB-GROUP: face-costume"
 msgid "face-costume"
-msgstr "костюмовані &amp; істоти"
+msgstr "маски"
 
 # 8
 msgctxt "EMOJI SUB-GROUP: face-glasses"
@@ -287,7 +287,7 @@ msgstr "гендерні ознаки"
 # 96
 msgctxt "EMOJI SUB-GROUP: geometric"
 msgid "geometric"
-msgstr "фігури та кольори"
+msgstr "фігури"
 
 # 33
 msgctxt "EMOJI SUB-GROUP: hair-style"
@@ -347,7 +347,7 @@ msgstr "символи клавіатури"
 # 71
 msgctxt "EMOJI SUB-GROUP: light-video"
 msgid "light-video"
-msgstr "світло, фільм &amp; відео"
+msgstr "світло, фільм та відео"
 
 # 77
 msgctxt "EMOJI SUB-GROUP: lock"
@@ -377,12 +377,12 @@ msgstr "гроші"
 # 13
 msgctxt "EMOJI SUB-GROUP: monkey-face"
 msgid "monkey-face"
-msgstr "мавпа особи"
+msgstr "мавпяче обличчя"
 
 # 67
 msgctxt "EMOJI SUB-GROUP: music"
 msgid "music"
-msgstr "музики"
+msgstr "музика"
 
 # 68
 msgctxt "EMOJI SUB-GROUP: musical-instrument"
@@ -412,7 +412,7 @@ msgstr "люди"
 # 27
 msgctxt "EMOJI SUB-GROUP: person-activity"
 msgid "person-activity"
-msgstr "діяльності"
+msgstr "діяльність людини"
 
 # 26
 msgctxt "EMOJI SUB-GROUP: person-fantasy"
@@ -427,12 +427,12 @@ msgstr "жести"
 # 29
 msgctxt "EMOJI SUB-GROUP: person-resting"
 msgid "person-resting"
-msgstr "відпочиваючи"
+msgstr "людина, що відпочиває"
 
 # 25
 msgctxt "EMOJI SUB-GROUP: person-role"
 msgid "person-role"
-msgstr "ролі та кар'єра"
+msgstr "роль людини"
 
 # 28
 msgctxt "EMOJI SUB-GROUP: person-sport"
@@ -462,7 +462,7 @@ msgstr "географічні розташування"
 # 49
 msgctxt "EMOJI SUB-GROUP: place-map"
 msgid "place-map"
-msgstr "глобуси &amp; карти"
+msgstr "глобуси та карти"
 
 # 53
 msgctxt "EMOJI SUB-GROUP: place-other"


### PR DESCRIPTION
I’m a native Ukrainian speaker and noticed several inaccuracies and unnatural phrases in the current Ukrainian translations.

This PR fixes those issues and makes the wording more natural and consistent with real Ukrainian usage.

Thanks for maintaining such a great package — it’s incredibly useful and well-structured!